### PR TITLE
파일 모듈 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ pids
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
+
+file-storage

--- a/src/files/config/file-config.type.ts
+++ b/src/files/config/file-config.type.ts
@@ -1,0 +1,14 @@
+export enum FileDriver {
+  LOCAL = 'local',
+  S3 = 's3',
+  S3_PRESIGNED = 's3-presigned',
+}
+
+export type FileConfig = {
+  driver: FileDriver;
+  accessKeyId?: string;
+  secretAccessKey?: string;
+  awsDefaultS3Bucket?: string;
+  awsS3Region?: string;
+  maxFileSize: number;
+};

--- a/src/files/config/file.config.ts
+++ b/src/files/config/file.config.ts
@@ -1,0 +1,48 @@
+import { registerAs } from '@nestjs/config';
+
+import { IsEnum, IsString, ValidateIf } from 'class-validator';
+import validateConfig from '../../utils/validate-config';
+import { FileDriver, FileConfig } from './file-config.type';
+
+class EnvironmentVariablesValidator {
+  @IsEnum(FileDriver)
+  FILE_DRIVER: FileDriver;
+
+  @ValidateIf((envValues) =>
+    [FileDriver.S3, FileDriver.S3_PRESIGNED].includes(envValues.FILE_DRIVER),
+  )
+  @IsString()
+  ACCESS_KEY_ID: string;
+
+  @ValidateIf((envValues) =>
+    [FileDriver.S3, FileDriver.S3_PRESIGNED].includes(envValues.FILE_DRIVER),
+  )
+  @IsString()
+  SECRET_ACCESS_KEY: string;
+
+  @ValidateIf((envValues) =>
+    [FileDriver.S3, FileDriver.S3_PRESIGNED].includes(envValues.FILE_DRIVER),
+  )
+  @IsString()
+  AWS_DEFAULT_S3_BUCKET: string;
+
+  @ValidateIf((envValues) =>
+    [FileDriver.S3, FileDriver.S3_PRESIGNED].includes(envValues.FILE_DRIVER),
+  )
+  @IsString()
+  AWS_S3_REGION: string;
+}
+
+export default registerAs<FileConfig>('file', () => {
+  validateConfig(process.env, EnvironmentVariablesValidator);
+
+  return {
+    driver:
+      (process.env.FILE_DRIVER as FileDriver | undefined) ?? FileDriver.LOCAL,
+    accessKeyId: process.env.ACCESS_KEY_ID,
+    secretAccessKey: process.env.SECRET_ACCESS_KEY,
+    awsDefaultS3Bucket: process.env.AWS_DEFAULT_S3_BUCKET,
+    awsS3Region: process.env.AWS_S3_REGION,
+    maxFileSize: 5242880, // 5mb
+  };
+});

--- a/src/files/domain/file.ts
+++ b/src/files/domain/file.ts
@@ -1,0 +1,47 @@
+import { Allow } from 'class-validator';
+import { Transform } from 'class-transformer';
+import fileConfig from '../config/file.config';
+import { FileConfig, FileDriver } from '../config/file-config.type';
+
+import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { AppConfig } from '../../config/app-config.type';
+import appConfig from '../../config/app.config';
+
+export class FileType {
+  @Allow()
+  id: string;
+
+  @Transform(
+    ({ value }) => {
+      if ((fileConfig() as FileConfig).driver === FileDriver.LOCAL) {
+        return (appConfig() as AppConfig).backendDomain + value;
+      } else if (
+        [FileDriver.S3_PRESIGNED, FileDriver.S3].includes(
+          (fileConfig() as FileConfig).driver,
+        )
+      ) {
+        const s3 = new S3Client({
+          region: (fileConfig() as FileConfig).awsS3Region ?? '',
+          credentials: {
+            accessKeyId: (fileConfig() as FileConfig).accessKeyId ?? '',
+            secretAccessKey: (fileConfig() as FileConfig).secretAccessKey ?? '',
+          },
+        });
+
+        const command = new GetObjectCommand({
+          Bucket: (fileConfig() as FileConfig).awsDefaultS3Bucket ?? '',
+          Key: value,
+        });
+
+        return getSignedUrl(s3, command, { expiresIn: 3600 });
+      }
+
+      return value;
+    },
+    {
+      toPlainOnly: true,
+    },
+  )
+  path: string;
+}

--- a/src/files/files.module.ts
+++ b/src/files/files.module.ts
@@ -1,0 +1,24 @@
+import { Module } from '@nestjs/common';
+import { RelationalFilePersistenceModule } from './infrastructure/persistence/relational/relational-persistence.module';
+import { FilesService } from './files.service';
+import fileConfig from './config/file.config';
+import { FileConfig, FileDriver } from './config/file-config.type';
+import { FilesLocalModule } from './infrastructure/uploader/local/files.module';
+import { FilesS3Module } from './infrastructure/uploader/s3/files.module';
+import { FilesS3PresignedModule } from './infrastructure/uploader/s3-presigned/files.module';
+
+const infrastructurePersistenceModule = RelationalFilePersistenceModule;
+
+const infrastructureUploaderModule =
+  (fileConfig() as FileConfig).driver === FileDriver.LOCAL
+    ? FilesLocalModule
+    : (fileConfig() as FileConfig).driver === FileDriver.S3
+      ? FilesS3Module
+      : FilesS3PresignedModule;
+
+@Module({
+  imports: [infrastructurePersistenceModule, infrastructureUploaderModule],
+  providers: [FilesService],
+  exports: [FilesService, infrastructurePersistenceModule],
+})
+export class FilesModule {}

--- a/src/files/files.service.ts
+++ b/src/files/files.service.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@nestjs/common';
+
+import { FileRepository } from './infrastructure/persistence/file.repository';
+import { FileType } from './domain/file';
+import { NullableType } from '../utils/types/nullable.type';
+
+@Injectable()
+export class FilesService {
+  constructor(private readonly fileRepository: FileRepository) {}
+
+  findById(id: FileType['id']): Promise<NullableType<FileType>> {
+    return this.fileRepository.findById(id);
+  }
+}

--- a/src/files/infrastructure/persistence/file.repository.ts
+++ b/src/files/infrastructure/persistence/file.repository.ts
@@ -1,0 +1,8 @@
+import { NullableType } from '../../../utils/types/nullable.type';
+import { FileType } from '../../domain/file';
+
+export abstract class FileRepository {
+  abstract create(data: Omit<FileType, 'id'>): Promise<FileType>;
+
+  abstract findById(id: FileType['id']): Promise<NullableType<FileType>>;
+}

--- a/src/files/infrastructure/persistence/relational/entities/file.entity.ts
+++ b/src/files/infrastructure/persistence/relational/entities/file.entity.ts
@@ -1,0 +1,48 @@
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import { Transform } from 'class-transformer';
+import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { AppConfig } from '../../../../../config/app-config.type';
+import appConfig from '../../../../../config/app.config';
+import { EntityRelationalHelper } from '../../../../../utils/relational-entity-helper';
+import { FileConfig, FileDriver } from '../../../../config/file-config.type';
+import fileConfig from '../../../../config/file.config';
+
+@Entity({ name: 'file' })
+export class FileEntity extends EntityRelationalHelper {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+  @Column()
+  @Transform(
+    ({ value }) => {
+      if ((fileConfig() as FileConfig).driver === FileDriver.LOCAL) {
+        return (appConfig() as AppConfig).backendDomain + value;
+      } else if (
+        [FileDriver.S3_PRESIGNED, FileDriver.S3].includes(
+          (fileConfig() as FileConfig).driver,
+        )
+      ) {
+        const s3 = new S3Client({
+          region: (fileConfig() as FileConfig).awsS3Region ?? '',
+          credentials: {
+            accessKeyId: (fileConfig() as FileConfig).accessKeyId ?? '',
+            secretAccessKey: (fileConfig() as FileConfig).secretAccessKey ?? '',
+          },
+        });
+
+        const command = new GetObjectCommand({
+          Bucket: (fileConfig() as FileConfig).awsDefaultS3Bucket ?? '',
+          Key: value,
+        });
+
+        return getSignedUrl(s3, command, { expiresIn: 3600 });
+      }
+
+      return value;
+    },
+    {
+      toPlainOnly: true,
+    },
+  )
+  path: string;
+}

--- a/src/files/infrastructure/persistence/relational/mappers/file.mapper.ts
+++ b/src/files/infrastructure/persistence/relational/mappers/file.mapper.ts
@@ -1,0 +1,18 @@
+import { FileType } from '../../../../domain/file';
+import { FileEntity } from '../entities/file.entity';
+
+export class FileMapper {
+  static toDomain(raw: FileEntity): FileType {
+    const domainEntity = new FileType();
+    domainEntity.id = raw.id;
+    domainEntity.path = raw.path;
+    return domainEntity;
+  }
+
+  static toPersistence(domainEntity: FileType): FileEntity {
+    const persistenceEntity = new FileEntity();
+    persistenceEntity.id = domainEntity.id;
+    persistenceEntity.path = domainEntity.path;
+    return persistenceEntity;
+  }
+}

--- a/src/files/infrastructure/persistence/relational/relational-persistence.module.ts
+++ b/src/files/infrastructure/persistence/relational/relational-persistence.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { FileEntity } from './entities/file.entity';
+import { FileRepository } from '../file.repository';
+import { FileRelationalRepository } from './repositories/file.repository';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([FileEntity])],
+  providers: [
+    {
+      provide: FileRepository,
+      useClass: FileRelationalRepository,
+    },
+  ],
+  exports: [FileRepository],
+})
+export class RelationalFilePersistenceModule {}

--- a/src/files/infrastructure/persistence/relational/repositories/file.repository.ts
+++ b/src/files/infrastructure/persistence/relational/repositories/file.repository.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { FileEntity } from '../entities/file.entity';
+import { Repository } from 'typeorm';
+import { FileRepository } from '../../file.repository';
+
+import { FileMapper } from '../mappers/file.mapper';
+import { FileType } from '../../../../domain/file';
+import { NullableType } from '../../../../../utils/types/nullable.type';
+
+@Injectable()
+export class FileRelationalRepository implements FileRepository {
+  constructor(
+    @InjectRepository(FileEntity)
+    private readonly fileRepository: Repository<FileEntity>,
+  ) {}
+
+  async create(data: FileType): Promise<FileType> {
+    const persistenceModel = FileMapper.toPersistence(data);
+    return this.fileRepository.save(
+      this.fileRepository.create(persistenceModel),
+    );
+  }
+
+  async findById(id: FileType['id']): Promise<NullableType<FileType>> {
+    const entity = await this.fileRepository.findOne({
+      where: {
+        id: id,
+      },
+    });
+
+    return entity ? FileMapper.toDomain(entity) : null;
+  }
+}

--- a/src/files/infrastructure/uploader/local/dto/file-response.dto.ts
+++ b/src/files/infrastructure/uploader/local/dto/file-response.dto.ts
@@ -1,0 +1,5 @@
+import { FileType } from '../../../../domain/file';
+
+export class FileResponseDto {
+  file: FileType;
+}

--- a/src/files/infrastructure/uploader/local/files.controller.ts
+++ b/src/files/infrastructure/uploader/local/files.controller.ts
@@ -1,0 +1,36 @@
+import {
+  Controller,
+  Get,
+  Param,
+  Post,
+  Response,
+  UploadedFile,
+  // UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+// import { AuthGuard } from '@nestjs/passport';
+import { FilesLocalService } from './files.service';
+import { FileResponseDto } from './dto/file-response.dto';
+
+@Controller({
+  path: 'files',
+  version: '1',
+})
+export class FilesLocalController {
+  constructor(private readonly filesService: FilesLocalService) {}
+
+  // @UseGuards(AuthGuard('jwt'))
+  @Post('upload')
+  @UseInterceptors(FileInterceptor('file'))
+  async uploadFile(
+    @UploadedFile() file: Express.Multer.File,
+  ): Promise<FileResponseDto> {
+    return this.filesService.create(file);
+  }
+
+  @Get(':path')
+  download(@Param('path') path, @Response() response) {
+    return response.sendFile(path, { root: './files' });
+  }
+}

--- a/src/files/infrastructure/uploader/local/files.module.ts
+++ b/src/files/infrastructure/uploader/local/files.module.ts
@@ -1,0 +1,64 @@
+import {
+  HttpStatus,
+  Module,
+  UnprocessableEntityException,
+} from '@nestjs/common';
+import { FilesLocalController } from './files.controller';
+import { MulterModule } from '@nestjs/platform-express';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { diskStorage } from 'multer';
+import { randomStringGenerator } from '@nestjs/common/utils/random-string-generator.util';
+
+import { FilesLocalService } from './files.service';
+import { RelationalFilePersistenceModule } from '../../persistence/relational/relational-persistence.module';
+import { AllConfigType } from '../../../../config/config.type';
+
+const infrastructurePersistenceModule = RelationalFilePersistenceModule;
+
+@Module({
+  imports: [
+    infrastructurePersistenceModule,
+    MulterModule.registerAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (configService: ConfigService<AllConfigType>) => {
+        return {
+          fileFilter: (request, file, callback) => {
+            if (!file.originalname.match(/\.(jpg|jpeg|png|gif)$/i)) {
+              return callback(
+                new UnprocessableEntityException({
+                  status: HttpStatus.UNPROCESSABLE_ENTITY,
+                  errors: {
+                    file: `cantUploadFileType`,
+                  },
+                }),
+                false,
+              );
+            }
+
+            callback(null, true);
+          },
+          storage: diskStorage({
+            destination: './file-storage',
+            filename: (request, file, callback) => {
+              callback(
+                null,
+                `${randomStringGenerator()}.${file.originalname
+                  .split('.')
+                  .pop()
+                  ?.toLowerCase()}`,
+              );
+            },
+          }),
+          limits: {
+            fileSize: configService.get('file.maxFileSize', { infer: true }),
+          },
+        };
+      },
+    }),
+  ],
+  controllers: [FilesLocalController],
+  providers: [ConfigModule, ConfigService, FilesLocalService],
+  exports: [FilesLocalService],
+})
+export class FilesLocalModule {}

--- a/src/files/infrastructure/uploader/local/files.service.ts
+++ b/src/files/infrastructure/uploader/local/files.service.ts
@@ -1,0 +1,37 @@
+import {
+  HttpStatus,
+  Injectable,
+  UnprocessableEntityException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+import { FileRepository } from '../../persistence/file.repository';
+import { AllConfigType } from '../../../../config/config.type';
+import { FileType } from '../../../domain/file';
+
+@Injectable()
+export class FilesLocalService {
+  constructor(
+    private readonly configService: ConfigService<AllConfigType>,
+    private readonly fileRepository: FileRepository,
+  ) {}
+
+  async create(file: Express.Multer.File): Promise<{ file: FileType }> {
+    if (!file) {
+      throw new UnprocessableEntityException({
+        status: HttpStatus.UNPROCESSABLE_ENTITY,
+        errors: {
+          file: 'selectFile',
+        },
+      });
+    }
+
+    return {
+      file: await this.fileRepository.create({
+        path: `/${this.configService.get('app.apiPrefix', {
+          infer: true,
+        })}/v1/${file.path}`,
+      }),
+    };
+  }
+}

--- a/src/files/infrastructure/uploader/s3-presigned/dto/file-response.dto.ts
+++ b/src/files/infrastructure/uploader/s3-presigned/dto/file-response.dto.ts
@@ -1,0 +1,7 @@
+import { FileType } from '../../../../domain/file';
+
+export class FileResponseDto {
+  file: FileType;
+
+  uploadSignedUrl: string;
+}

--- a/src/files/infrastructure/uploader/s3-presigned/dto/file.dto.ts
+++ b/src/files/infrastructure/uploader/s3-presigned/dto/file.dto.ts
@@ -1,0 +1,9 @@
+import { IsNumber, IsString } from 'class-validator';
+
+export class FileUploadDto {
+  @IsString()
+  fileName: string;
+
+  @IsNumber()
+  fileSize: number;
+}

--- a/src/files/infrastructure/uploader/s3-presigned/files.controller.ts
+++ b/src/files/infrastructure/uploader/s3-presigned/files.controller.ts
@@ -1,0 +1,18 @@
+import { Body, Controller, Post, UseGuards } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { FilesS3PresignedService } from './files.service';
+import { FileUploadDto } from './dto/file.dto';
+
+@Controller({
+  path: 'files',
+  version: '1',
+})
+export class FilesS3PresignedController {
+  constructor(private readonly filesService: FilesS3PresignedService) {}
+
+  @UseGuards(AuthGuard('jwt'))
+  @Post('upload')
+  async uploadFile(@Body() file: FileUploadDto) {
+    return this.filesService.create(file);
+  }
+}

--- a/src/files/infrastructure/uploader/s3-presigned/files.module.ts
+++ b/src/files/infrastructure/uploader/s3-presigned/files.module.ts
@@ -1,0 +1,80 @@
+import {
+  HttpStatus,
+  Module,
+  UnprocessableEntityException,
+} from '@nestjs/common';
+import { FilesS3PresignedController } from './files.controller';
+import { MulterModule } from '@nestjs/platform-express';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { randomStringGenerator } from '@nestjs/common/utils/random-string-generator.util';
+import { S3Client } from '@aws-sdk/client-s3';
+import multerS3 from 'multer-s3';
+
+import { FilesS3PresignedService } from './files.service';
+import { RelationalFilePersistenceModule } from '../../persistence/relational/relational-persistence.module';
+import { AllConfigType } from '../../../../config/config.type';
+
+const infrastructurePersistenceModule = RelationalFilePersistenceModule;
+
+@Module({
+  imports: [
+    infrastructurePersistenceModule,
+    MulterModule.registerAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (configService: ConfigService<AllConfigType>) => {
+        const s3 = new S3Client({
+          region: configService.get('file.awsS3Region', { infer: true }),
+          credentials: {
+            accessKeyId: configService.getOrThrow('file.accessKeyId', {
+              infer: true,
+            }),
+            secretAccessKey: configService.getOrThrow('file.secretAccessKey', {
+              infer: true,
+            }),
+          },
+        });
+
+        return {
+          fileFilter: (request, file, callback) => {
+            if (!file.originalname.match(/\.(jpg|jpeg|png|gif)$/i)) {
+              return callback(
+                new UnprocessableEntityException({
+                  status: HttpStatus.UNPROCESSABLE_ENTITY,
+                  errors: {
+                    file: `cantUploadFileType`,
+                  },
+                }),
+                false,
+              );
+            }
+
+            callback(null, true);
+          },
+          storage: multerS3({
+            s3: s3,
+            bucket: '',
+            acl: 'public-read',
+            contentType: multerS3.AUTO_CONTENT_TYPE,
+            key: (request, file, callback) => {
+              callback(
+                null,
+                `${randomStringGenerator()}.${file.originalname
+                  .split('.')
+                  .pop()
+                  ?.toLowerCase()}`,
+              );
+            },
+          }),
+          limits: {
+            fileSize: configService.get('file.maxFileSize', { infer: true }),
+          },
+        };
+      },
+    }),
+  ],
+  controllers: [FilesS3PresignedController],
+  providers: [ConfigModule, ConfigService, FilesS3PresignedService],
+  exports: [FilesS3PresignedService],
+})
+export class FilesS3PresignedModule {}

--- a/src/files/infrastructure/uploader/s3-presigned/files.service.ts
+++ b/src/files/infrastructure/uploader/s3-presigned/files.service.ts
@@ -1,0 +1,93 @@
+import {
+  HttpStatus,
+  Injectable,
+  PayloadTooLargeException,
+  UnprocessableEntityException,
+} from '@nestjs/common';
+import { FileRepository } from '../../persistence/file.repository';
+
+import { FileUploadDto } from './dto/file.dto';
+import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { randomStringGenerator } from '@nestjs/common/utils/random-string-generator.util';
+import { ConfigService } from '@nestjs/config';
+import { FileType } from '../../../domain/file';
+
+@Injectable()
+export class FilesS3PresignedService {
+  private s3: S3Client;
+
+  constructor(
+    private readonly fileRepository: FileRepository,
+    private readonly configService: ConfigService,
+  ) {
+    this.s3 = new S3Client({
+      region: configService.get('file.awsS3Region', { infer: true }),
+      credentials: {
+        accessKeyId: configService.getOrThrow('file.accessKeyId', {
+          infer: true,
+        }),
+        secretAccessKey: configService.getOrThrow('file.secretAccessKey', {
+          infer: true,
+        }),
+      },
+    });
+  }
+
+  async create(
+    file: FileUploadDto,
+  ): Promise<{ file: FileType; uploadSignedUrl: string }> {
+    if (!file) {
+      throw new UnprocessableEntityException({
+        status: HttpStatus.UNPROCESSABLE_ENTITY,
+        errors: {
+          file: 'selectFile',
+        },
+      });
+    }
+
+    if (!file.fileName.match(/\.(jpg|jpeg|png|gif)$/i)) {
+      throw new UnprocessableEntityException({
+        status: HttpStatus.UNPROCESSABLE_ENTITY,
+        errors: {
+          file: `cantUploadFileType`,
+        },
+      });
+    }
+
+    if (
+      file.fileSize >
+      (this.configService.get('file.maxFileSize', {
+        infer: true,
+      }) || 0)
+    ) {
+      throw new PayloadTooLargeException({
+        statusCode: HttpStatus.PAYLOAD_TOO_LARGE,
+        error: 'Payload Too Large',
+        message: 'File too large',
+      });
+    }
+
+    const key = `${randomStringGenerator()}.${file.fileName
+      .split('.')
+      .pop()
+      ?.toLowerCase()}`;
+
+    const command = new PutObjectCommand({
+      Bucket: this.configService.getOrThrow('file.awsDefaultS3Bucket', {
+        infer: true,
+      }),
+      Key: key,
+      ContentLength: file.fileSize,
+    });
+    const signedUrl = await getSignedUrl(this.s3, command, { expiresIn: 3600 });
+    const data = await this.fileRepository.create({
+      path: key,
+    });
+
+    return {
+      file: data,
+      uploadSignedUrl: signedUrl,
+    };
+  }
+}

--- a/src/files/infrastructure/uploader/s3/dto/file-response.dto.ts
+++ b/src/files/infrastructure/uploader/s3/dto/file-response.dto.ts
@@ -1,0 +1,5 @@
+import { FileType } from '../../../../domain/file';
+
+export class FileResponseDto {
+  file: FileType;
+}

--- a/src/files/infrastructure/uploader/s3/files.controller.ts
+++ b/src/files/infrastructure/uploader/s3/files.controller.ts
@@ -1,0 +1,28 @@
+import {
+  Controller,
+  Post,
+  UploadedFile,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { AuthGuard } from '@nestjs/passport';
+import { FilesS3Service } from './files.service';
+import { FileResponseDto } from './dto/file-response.dto';
+
+@Controller({
+  path: 'files',
+  version: '1',
+})
+export class FilesS3Controller {
+  constructor(private readonly filesService: FilesS3Service) {}
+
+  @UseGuards(AuthGuard('jwt'))
+  @Post('upload')
+  @UseInterceptors(FileInterceptor('file'))
+  async uploadFile(
+    @UploadedFile() file: Express.MulterS3.File,
+  ): Promise<FileResponseDto> {
+    return this.filesService.create(file);
+  }
+}

--- a/src/files/infrastructure/uploader/s3/files.module.ts
+++ b/src/files/infrastructure/uploader/s3/files.module.ts
@@ -1,0 +1,81 @@
+import {
+  HttpStatus,
+  Module,
+  UnprocessableEntityException,
+} from '@nestjs/common';
+import { FilesS3Controller } from './files.controller';
+import { MulterModule } from '@nestjs/platform-express';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { randomStringGenerator } from '@nestjs/common/utils/random-string-generator.util';
+import { S3Client } from '@aws-sdk/client-s3';
+import multerS3 from 'multer-s3';
+
+import { FilesS3Service } from './files.service';
+import { RelationalFilePersistenceModule } from '../../persistence/relational/relational-persistence.module';
+import { AllConfigType } from '../../../../config/config.type';
+
+const infrastructurePersistenceModule = RelationalFilePersistenceModule;
+
+@Module({
+  imports: [
+    infrastructurePersistenceModule,
+    MulterModule.registerAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (configService: ConfigService<AllConfigType>) => {
+        const s3 = new S3Client({
+          region: configService.get('file.awsS3Region', { infer: true }),
+          credentials: {
+            accessKeyId: configService.getOrThrow('file.accessKeyId', {
+              infer: true,
+            }),
+            secretAccessKey: configService.getOrThrow('file.secretAccessKey', {
+              infer: true,
+            }),
+          },
+        });
+
+        return {
+          fileFilter: (request, file, callback) => {
+            if (!file.originalname.match(/\.(jpg|jpeg|png|gif)$/i)) {
+              return callback(
+                new UnprocessableEntityException({
+                  status: HttpStatus.UNPROCESSABLE_ENTITY,
+                  errors: {
+                    file: `cantUploadFileType`,
+                  },
+                }),
+                false,
+              );
+            }
+
+            callback(null, true);
+          },
+          storage: multerS3({
+            s3: s3,
+            bucket: configService.getOrThrow('file.awsDefaultS3Bucket', {
+              infer: true,
+            }),
+            contentType: multerS3.AUTO_CONTENT_TYPE,
+            key: (request, file, callback) => {
+              callback(
+                null,
+                `${randomStringGenerator()}.${file.originalname
+                  .split('.')
+                  .pop()
+                  ?.toLowerCase()}`,
+              );
+            },
+          }),
+          limits: {
+            fileSize: configService.get('file.maxFileSize', { infer: true }),
+          },
+        };
+      },
+    }),
+  ],
+  controllers: [FilesS3Controller],
+  providers: [FilesS3Service],
+  exports: [FilesS3Service],
+})
+export class FilesS3Module {}

--- a/src/files/infrastructure/uploader/s3/files.service.ts
+++ b/src/files/infrastructure/uploader/s3/files.service.ts
@@ -1,0 +1,29 @@
+import {
+  HttpStatus,
+  Injectable,
+  UnprocessableEntityException,
+} from '@nestjs/common';
+import { FileRepository } from '../../persistence/file.repository';
+import { FileType } from '../../../domain/file';
+
+@Injectable()
+export class FilesS3Service {
+  constructor(private readonly fileRepository: FileRepository) {}
+
+  async create(file: Express.MulterS3.File): Promise<{ file: FileType }> {
+    if (!file) {
+      throw new UnprocessableEntityException({
+        status: HttpStatus.UNPROCESSABLE_ENTITY,
+        errors: {
+          file: 'selectFile',
+        },
+      });
+    }
+
+    return {
+      file: await this.fileRepository.create({
+        path: file.key,
+      }),
+    };
+  }
+}

--- a/src/utils/types/nullable.type.ts
+++ b/src/utils/types/nullable.type.ts
@@ -1,0 +1,1 @@
+export type NullableType<T> = T | null;


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

```markdown
파일 모듈을 추가했습니다.
환경에 따라 서버 파일시스템 / s3에 업로드 하며, s3-presigned url을 생성하는 로직이 포함되어 있습니다.
```

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- ✨ 파일 모듈 설정 및 환경 분리
- ✨ local, s3, s3-presigned별 모듈 및 관련 컨트롤러, 서비스, dto 추가
- ✨ 파일 엔티티 추가 및 s3 presigned url 생성 로직 구현
- ✨ 파일 도메인 및 퍼시스턴트 매퍼 구현
- ✨ gitignore에 로컬 파일 저장 폴더 추가
- ✨ Nullable 타입 유틸리티 추가

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략)) -->

- closed #9